### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @NoumenaDigital/teams/noumena-lsp-reviewers
+*  @NoumenaDigital/noumena-lsp-reviewers


### PR DESCRIPTION
Adds a CODEOWNERS file, which will restrict PR approvals to @NoumenaDigital/noumena-lsp-reviewers  (as defined in NoumenaDigital/user-management).

Release: false