### PR TITLE
chore: Update release flow for OSX x86

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
             output_name: language-server-linux-aarch64
             static: false
           - os: macos
-            runner: macos-15
+            runner: macos-15-intel
             arch: x86_64
             output_name: language-server-macos-x86_64
             static: false


### PR DESCRIPTION
* Fix the release flow to explicitly use the intel runner for OSX x86 releases

Release: true
